### PR TITLE
Corrección de comas en archivo index.js de funciones-base/fs

### DIFF
--- a/node/funciones_base/fs/index.js
+++ b/node/funciones_base/fs/index.js
@@ -7,26 +7,26 @@ fs.chmod(path, mode, callback);
 fs.chown(path, uid, gid, callback);
 
 // Para escribir y crear un archivo
-fs.writeFile(file, data[, options], callback);
+fs.writeFile(file, data, [options], callback);
 
 // Abrir un archivo
-fs.open(path[, flags[, mode]], callback);
+fs.open(path, [flags, [mode]], callback);
 
 // Abrir un directorio
-fs.opendir(path[, options], callback);
+fs.opendir(path, [options], callback);
 
 // Leer un archivo
-fs.readFile(path[, options]);
+fs.readFile(path, [options]);
 
 // Ejecuta un callback en una path
-fs.realpath(path[, options], callback);
+fs.realpath(path, [options], callback);
 
 // Renombrar un archivo
 fs.rename(oldPath, newPath, callback);
 
 // Elimina un directorio
-fs.rmdir(path[, options], callback);
+fs.rmdir(path, [options], callback);
 
 // Elimina un archivo
-fs.rm(path[, options], callback);
+fs.rm(path, [options], callback);
 


### PR DESCRIPTION
* Solucionar error de sintáxis en archivo index.js de funciones-base/fs moviendo las comas al lugar adecuado